### PR TITLE
Update plugin with mixin implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ npm install objection-slugify --save
 ## Usage
 ```js
 // Import the plugin.
-const Slugify = require('objection-slugify');
+const slugifyPlugin = require('objection-slugify');
 const { Model } = require('objection');
 
 // Mixin the plugin.
-const SluggedModel = Slugify(Model, {
+const slugify = slugifyPlugin({
   sourceField: 'title',
   slugField: 'slug',
   unique: true
 });
 
 // Create your model.
-class Post extends SluggedModel {
+class Post extends slugify(Model) {
   // ...code
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,32 +2,32 @@ const slugify = require('slug');
 
 /**
  * Adds hooks to an Objection.Model to slugify from a source field.
- * @param {Objection.Model} The model class
  * @param {String} options.sourceField - Source field to slugify. Default: null
  * @param {String} options.slugField - Field to slugify. Default: 'slug'.
  * @param {Boolean} options.unique - Ensure slugs are unique. Default: false
+ * @param {Objection.Model} The model class
  */
-module.exports = {
-  Slugify: (Model, options) => {
-    // Provide some default options
-    const opts = Object.assign(
-      {
-        // The source field, or the source field to slugify
-        sourceField: null,
+module.exports = options => {
+  // Provide some default options
+  const opts = Object.assign(
+    {
+      // The source field, or the source field to slugify
+      sourceField: null,
 
-        // The name of the field to save the slug to
-        slugField: 'slug',
+      // The name of the field to save the slug to
+      slugField: 'slug',
 
-        // Ensure slugs are unique.
-        unique: false
-      },
-      options
-    );
+      // Ensure slugs are unique.
+      unique: false
+    },
+    options
+  );
 
-    if (!opts.sourceField || !opts.slugField) {
-      throw new Error('You must specify `sourceField` and `slugField`.');
-    }
+  if (!opts.sourceField || !opts.slugField) {
+    throw new Error('You must specify `sourceField` and `slugField`.');
+  }
 
+  return Model => {
     return class extends Model {
       $beforeInsert(context) {
         const maybePromise = super.$beforeInsert(context);
@@ -112,5 +112,5 @@ module.exports = {
         return current || original;
       };
     };
-  }
+  };
 };

--- a/test/support/User.js
+++ b/test/support/User.js
@@ -1,13 +1,13 @@
 import { Model } from 'objection';
-import { Slugify } from '../../src/index';
+import slugifyPlugin from '../../src/index';
 
-const SluggedModel = Slugify(Model, {
+const slugify = slugifyPlugin({
   sourceField: 'name',
   slugField: 'slugged',
   unique: true
 });
 
-export default class User extends SluggedModel {
+export default class User extends slugify(Model) {
   static modelPaths = [__dirname];
   static tableName = 'users';
   static jsonSchema = {


### PR DESCRIPTION
This PR updates the plugin with mixin implementation:

- Receive `options` and returns a function which accepts `model` as argument.  

Also, it updates the plugin name to `slugify` instead of `Slugify` because `objection` plugin are functions and not classes, so should be named lowercase.  
Also, it update the module to be exported as default function instead of an object with a single method.

The documentation is updated to reflect this changes. 

This PR is a breaking change. 

@calvinl , the important part of this PR is the mixin implementation, the others changes i think are best practices which i believe it will improve the quality of this plugin! 

Great job, this is just the plugin i'm looking for, and i particularly like the detail of `option.unique`, so i hope this can be merged to start using it!
