### PR TITLE
Fix npm scripts failing if a parent directory name contains a space

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "main": "dist/index.js",
   "scripts": {
-    "build": "$(npm bin)/babel src -d dist",
-    "jest": "$(npm bin)/jest -c ./test/support/jest.config.js",
+    "build": "babel src -d dist",
+    "jest": "jest -c ./test/support/jest.config.js",
     "test": "npm run jest",
     "test:watch": "npm run jest -- --watch",
     "cover": "npm run jest -- --coverage --forceExit",
-    "coveralls": "npm run cover && cat ./test/coverage/lcov.info | $(npm bin)/coveralls",
+    "coveralls": "npm run cover && cat ./test/coverage/lcov.info | coveralls",
     "prepublish": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
Using `$(npm bin)` is problematic because it doesn’t escape spaces, which on some operating systems, like macOS, is valid in file and directory names. This causes the `build` and `test` scripts to fail if any of the parent directories of objection-slugify contain a space.

npm adds the `npm bin` path to the `PATH` environment variable automatically when evaluating scripts, so prepending the path in this context isn’t necessary. (The locally installed versions of these command-line tools will still be used instead of any globally installed ones.)

https://docs.npmjs.com/cli/run-script:
> In addition to the shell's pre-existing PATH, npm run adds node_modules/.bin to the PATH provided to scripts. Any binaries provided by locally-installed dependencies can be used without the node_modules/.bin prefix.