### PR TITLE
Allow passing through slugifyOptions - Fixes #6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,5 +13,6 @@
   "plugins": [
     "transform-es2015-modules-commonjs",
     "transform-class-properties",
+    "babel-plugin-transform-object-rest-spread"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ append a UUID to the end of the slug.
 A custom function that returns a string. Can be used to generate a custom suffix
 to the end of the slug. If `unique` is true and this is not specified, a random
 UUID will be appended to the slug.
+
+#### `slugifyOptions` (defaults to `{ lower: true } `)
+A set of options for the internal slugify library, options available [here](https://www.npmjs.com/package/slugify#options).

--- a/package-lock.json
+++ b/package-lock.json
@@ -858,6 +858,16 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-jest": "^23.0.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "coveralls": "^3.0.0",
     "faker": "^4.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ module.exports = options => {
       slugField: 'slug',
       update: true,
       unique: false,
-      generateUniqueSuffix: null
+      generateUniqueSuffix: null,
+      slugifyOptions: {},
     },
     options
   );
@@ -67,7 +68,7 @@ module.exports = options => {
       }
 
       generateSlug = async str => {
-        const slug = slugify(str, { lower: true });
+        const slug = slugify(str, Object.assign({}, { lower: true }, opts.slugifyOptions));
 
         if (opts.unique) {
           return await this.uniqueSlug(slug);

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ module.exports = options => {
       }
 
       generateSlug = async str => {
-        const slug = slugify(str, Object.assign({}, { lower: true }, opts.slugifyOptions));
+        const slug = slugify(str, { lower: true, ...opts.slugifyOptions });
 
         if (opts.unique) {
           return await this.uniqueSlug(slug);

--- a/test/spec/unit.test.js
+++ b/test/spec/unit.test.js
@@ -1,0 +1,66 @@
+import slugifyPlugin from '../../src/index';
+import { Model } from 'objection';
+
+// Set up assertions on slugify
+let mockSlugifyAssertions = (str, opts) => { return str };
+
+jest.mock('slugify', () => (str, opts) => {
+    return mockSlugifyAssertions(str, opts);
+});
+
+describe('generateSlug', function() {
+  it('will default options to lower: true', function() {
+    mockSlugifyAssertions = (str, opts) => {
+      expect(opts)
+        .toEqual({ lower: true });
+
+      return 'Asserted default options';
+    };
+
+    const slugifyMixin = slugifyPlugin({
+      sourceField: 'name',
+      slugField: 'slugged',
+      slugifyOptions: {
+        // 
+      }
+    });
+  
+    const model = new class MockModel extends slugifyMixin(Model) {}
+
+    return model.generateSlug('slug test creation')
+      .then((slug) => {
+        expect(slug)
+          .toEqual('Asserted default options');
+      })
+  });
+
+  it('will pass slugifyOptions', function() {
+    mockSlugifyAssertions = (str, opts) => {
+      expect(opts)
+        .toEqual({
+          lower: true,
+          test: 'an-option',
+          remove: 'an actual option'
+        });
+
+      return 'Asserted overridden options';
+    };
+
+    const slugifyMixin = slugifyPlugin({
+      sourceField: 'name',
+      slugField: 'slugged',
+      slugifyOptions: {
+        test: 'an-option',
+        remove: 'an actual option'
+      }
+    });
+  
+    const model = new class MockModel extends slugifyMixin(Model) {}
+
+    return model.generateSlug('slug test creation')
+      .then((slug) => {
+        expect(slug)
+          .toEqual('Asserted overridden options');
+      })
+  });
+});


### PR DESCRIPTION
I've added the option to pass through options directly to slugify internally, I tried to find a way to unit test whether slugify was receiving the correct options but was struggling with mocking external dependencies with Jest (I've used Mocha, Chai and TS Mockito but not Jest before).

Is there an easy way we can test that without testing the actual output of running insert / generateSlug with a bunch of options?